### PR TITLE
TrustGraph Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ We encode TrustAtoms as links, with the following components:
 
 ```
 Ŧ→[0x00]prefix[0x00]sushi[0x00]0.999999999[0x00]892412523[0x00]uhCEk…UFnFF
+<<<<<<< HEAD
 Ŧ↩[0x00]prefix[0x00]sushi[0x00]0.999999999[0x00]892412523[0x00]uhCEk…UFnFF
 
 Ŧ→[0x00]rollup[0x00]content[0x00]0.800000000[0x00]087423432[0x00]uhCEk…qS5wc
@@ -135,6 +136,16 @@ We encode TrustAtoms as links, with the following components:
 
 Ŧ→[0x00]entry[0x00]spam[0x00]-0.999999999[0x00]328425615[0x00]uhCEk…VaaDd
 Ŧ→[0x00]agent[0x00]block[0x00]-0.999999999[0x00]837592944[0x00]uhCEk…VaaDd
+=======
+Ŧ→[0x00]sushi[0x00]0.999999999[0x00]892412523[0x00]uhCEk…UFnFF
+Ŧ↩[0x00]sushi[0x00]0.999999999[0x00]892412523[0x00]uhCEk…UFnFF
+
+Ŧ→[0x00]sushi[0x00]0.800000000[0x00]087423432[0x00]uhCEk…qS5wc
+Ŧ↩[0x00]sushi[0x00]0.800000000[0x00]087423432[0x00]uhCEk…qS5wc
+
+Ŧ→[0x00]spam[0x00]-0.999999999[0x00]328425615[0x00]uhCEk…VaaDd
+Ŧ→agent[0x00]block[0x00]-0.999999999[0x00]837592944[0x00]uhCEk…VaaDd
+>>>>>>> 5376c48 (add label (type) to TA)
 ```
 
 ## Roadmap

--- a/zomes/hc_zome_trust_atom/src/lib.rs
+++ b/zomes/hc_zome_trust_atom/src/lib.rs
@@ -33,8 +33,8 @@ entry_defs![
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 pub struct TrustAtomInput {
-pub prefix: Option<String>,
-pub target: AnyLinkableHash,
+  pub prefix: Option<String>,
+  pub target: AnyLinkableHash,
   pub source: EntryHash, //// for testing purposes ////
   pub content: Option<String>,
   pub value: Option<String>,
@@ -45,8 +45,8 @@ pub target: AnyLinkableHash,
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 pub struct QueryInput {
-pub source: Option<AnyLinkableHash>,
-pub target: Option<AnyLinkableHash>,
+  pub source: Option<AnyLinkableHash>,
+  pub target: Option<AnyLinkableHash>,
   pub prefix: Option<String>,
   pub content_full: Option<String>,
   pub content_starts_with: Option<String>,
@@ -55,7 +55,7 @@ pub target: Option<AnyLinkableHash>,
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 pub struct QueryMineInput {
-pub target: Option<AnyLinkableHash>,
+  pub target: Option<AnyLinkableHash>,
   pub prefix: Option<String>,
   pub content_full: Option<String>,
   pub content_starts_with: Option<String>,
@@ -72,7 +72,6 @@ pub fn create_rollup_atoms(_: ()) -> ExternResult<Vec<TrustAtom>> {
 #[hdk_extern]
 pub fn create_trust_atom(input: TrustAtomInput) -> ExternResult<TrustAtom> {
   trust_atom::create_trust_atom(
-    input.source,
     input.target,
     input.prefix,
     input.content,
@@ -109,6 +108,18 @@ pub fn query_mine(input: QueryMineInput) -> ExternResult<Vec<TrustAtom>> {
   )
 }
 // TEST HELPERS
+
+// #[hdk_extern]
+// pub fn test_helper_create_trust_atom(input: TrustAtomInput) -> ExternResult<TrustAtom> {
+//   trust_atom::create_trust_atom(
+//     input.source,
+//     input.target,
+//     input.prefix,
+//     input.content,
+//     input.value,
+//     input.extra,
+//   )
+// }
 
 #[hdk_extern]
 pub fn create_string_target(input: String) -> ExternResult<EntryHash> {

--- a/zomes/hc_zome_trust_atom/src/lib.rs
+++ b/zomes/hc_zome_trust_atom/src/lib.rs
@@ -81,9 +81,7 @@ pub fn create_rollup_atoms(_: ()) -> ExternResult<Vec<TrustAtom>> {
 
 #[hdk_extern]
 pub fn create_trust_atom(input: TrustAtomInput) -> ExternResult<TrustAtom> {
-  let agent_address = AnyLinkableHash::from(agent_info()?.agent_initial_pubkey);
-  trust_atom::create_trust_atom(
-    agent_address,
+  trust_atom::create_mine_trust_atom(
     input.target,
     input.prefix,
     input.content,

--- a/zomes/hc_zome_trust_atom/src/lib.rs
+++ b/zomes/hc_zome_trust_atom/src/lib.rs
@@ -38,9 +38,9 @@ pub struct TrustAtomInput {
   pub target: AnyLinkableHash,
   pub content: Option<String>,
   pub value: Option<String>,
-  pub extra: Option<BTreeMap<String, String>>, 
-                                               // for rollups key is "rolled_up_trust_atoms"
-                                               // value is json: '["header hash of atom 1","header hash of atom 2"...]'
+  pub extra: Option<BTreeMap<String, String>>,
+  // for rollups key is "rolled_up_trust_atoms"
+  // value is json: '["header hash of atom 1","header hash of atom 2"...]'
 }
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]

--- a/zomes/hc_zome_trust_atom/src/lib.rs
+++ b/zomes/hc_zome_trust_atom/src/lib.rs
@@ -37,12 +37,21 @@ entry_defs![
 pub struct TrustAtomInput {
   pub prefix: Option<String>,
   pub target: AnyLinkableHash,
-  pub source: EntryHash, //// for testing purposes ////
   pub content: Option<String>,
   pub value: Option<String>,
   pub extra: Option<BTreeMap<String, String>>, // TODO back to String -> String
                                                // for rollups key is "rolled_up_trust_atoms"
                                                // value is json: '["header hash of atom 1","header hash of atom 2"...]'
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct TestHelperTrustAtomInput {
+  pub source: AnyLinkableHash,
+  pub prefix: Option<String>,
+  pub target: AnyLinkableHash,
+  pub content: Option<String>,
+  pub value: Option<String>,
+  pub extra: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
@@ -73,7 +82,22 @@ pub fn create_rollup_atoms(_: ()) -> ExternResult<Vec<TrustAtom>> {
 
 #[hdk_extern]
 pub fn create_trust_atom(input: TrustAtomInput) -> ExternResult<TrustAtom> {
-  trust_atom::_create_trust_atom(
+  let agent_address = AnyLinkableHash::from(agent_info()?.agent_initial_pubkey);
+  trust_atom::create_trust_atom(
+    agent_address,
+    input.target,
+    input.prefix,
+    input.content,
+    input.value,
+    input.extra,
+  )
+}
+
+#[hdk_extern]
+// TEST HELPER move me
+pub fn test_helper_create_trust_atom(input: TestHelperTrustAtomInput) -> ExternResult<TrustAtom> {
+  trust_atom::create_trust_atom(
+    input.source,
     input.target,
     input.prefix,
     input.content,
@@ -109,19 +133,8 @@ pub fn query_mine(input: QueryMineInput) -> ExternResult<Vec<TrustAtom>> {
     input.value_starts_with,
   )
 }
-// TEST HELPERS
 
-// #[hdk_extern]
-// pub fn test_helper_create_trust_atom(input: TrustAtomInput) -> ExternResult<TrustAtom> {
-//   trust_atom::create_trust_atom(
-//     input.source,
-//     input.target,
-//     input.prefix,
-//     input.content,
-//     input.value,
-//     input.extra,
-//   )
-// }
+// TEST HELPERS
 
 #[hdk_extern]
 pub fn create_string_target(input: String) -> ExternResult<EntryHash> {

--- a/zomes/hc_zome_trust_atom/src/lib.rs
+++ b/zomes/hc_zome_trust_atom/src/lib.rs
@@ -22,6 +22,8 @@ pub mod trust_graph;
 pub use trust_graph::*;
 pub mod test_helpers;
 pub use test_helpers::Test;
+pub mod utils;
+pub use utils::*;
 
 entry_defs![
   test_helpers::StringTarget::entry_def(),
@@ -71,7 +73,7 @@ pub fn create_rollup_atoms(_: ()) -> ExternResult<Vec<TrustAtom>> {
 
 #[hdk_extern]
 pub fn create_trust_atom(input: TrustAtomInput) -> ExternResult<TrustAtom> {
-  trust_atom::create_trust_atom(
+  trust_atom::_create_trust_atom(
     input.target,
     input.prefix,
     input.content,

--- a/zomes/hc_zome_trust_atom/src/lib.rs
+++ b/zomes/hc_zome_trust_atom/src/lib.rs
@@ -10,7 +10,6 @@
 
 // #![warn(clippy::cargo)]
 
-use hdk::prelude::holo_hash::EntryHashB64;
 use hdk::prelude::*;
 
 use std::collections::BTreeMap;
@@ -39,7 +38,7 @@ pub struct TrustAtomInput {
   pub target: AnyLinkableHash,
   pub content: Option<String>,
   pub value: Option<String>,
-  pub extra: Option<BTreeMap<String, String>>, // TODO back to String -> String
+  pub extra: Option<BTreeMap<String, String>>, 
                                                // for rollups key is "rolled_up_trust_atoms"
                                                // value is json: '["header hash of atom 1","header hash of atom 2"...]'
 }
@@ -127,6 +126,7 @@ pub fn query(input: QueryInput) -> ExternResult<Vec<TrustAtom>> {
 #[hdk_extern]
 pub fn query_mine(input: QueryMineInput) -> ExternResult<Vec<TrustAtom>> {
   trust_atom::query_mine(
+    input.target,
     input.prefix,
     input.content_full,
     input.content_starts_with,

--- a/zomes/hc_zome_trust_atom/src/test_helpers.rs
+++ b/zomes/hc_zome_trust_atom/src/test_helpers.rs
@@ -80,11 +80,8 @@ fn get_element_by_header(
       header_hash
     ))),
   }
-pub fn calc_extra_hash(input: Extra) -> ExternResult<EntryHash> {
-  hash_entry(input)
 }
 
-fn link_tag(tag: String) -> ExternResult<LinkTag> {
-  let serialized_bytes: SerializedBytes = StringLinkTag(tag).try_into()?;
-  Ok(LinkTag(serialized_bytes.bytes().clone()))
+pub fn calc_extra_hash(input: Extra) -> ExternResult<EntryHash> {
+  hash_entry(input)
 }

--- a/zomes/hc_zome_trust_atom/src/test_helpers.rs
+++ b/zomes/hc_zome_trust_atom/src/test_helpers.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
+use crate::trust_atom::Extra;
 use hdk::prelude::*;
 
 #[derive(Serialize, Deserialize, Debug, SerializedBytes)]
@@ -79,4 +80,11 @@ fn get_element_by_header(
       header_hash
     ))),
   }
+pub fn calc_extra_hash(input: Extra) -> ExternResult<EntryHash> {
+  hash_entry(input)
+}
+
+fn link_tag(tag: String) -> ExternResult<LinkTag> {
+  let serialized_bytes: SerializedBytes = StringLinkTag(tag).try_into()?;
+  Ok(LinkTag(serialized_bytes.bytes().clone()))
 }

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -52,13 +52,13 @@ pub struct Extra {
 //   extra: Option<BTreeMap<String, String>>,
 // ) -> ExternResult<TrustAtom> {
 // set source to me
-// _create_trust_atom(
+// create_trust_atom(
 // source: me
 // ...
 // )
 
-pub fn _create_trust_atom(
-  source: EntryHash, //// for tests ////
+pub fn create_trust_atom(
+  source: AnyLinkableHash,
   target: AnyLinkableHash,
   prefix: Option<String>,
   content: Option<String>,

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -62,7 +62,6 @@ pub fn create_trust_atom(
   value: Option<String>,
   extra: Option<BTreeMap<String, String>>,
 ) -> ExternResult<TrustAtom> {
-  let agent_address = AnyLinkableHash::from(source);
 
   let bucket = create_bucket()?;
 
@@ -86,21 +85,21 @@ pub fn create_trust_atom(
   // );
 
   create_link(
-    agent_address.clone(),
+    source.clone(),
     target.clone(),
     HdkLinkType::Any,
     forward_link_tag,
   )?;
   create_link(
     target.clone(),
-    agent_address.clone(),
+    SourceChainResult.clone(),
     HdkLinkType::Any,
     reverse_link_tag,
   )?;
 
   let trust_atom = TrustAtom {
-    source_entry_hash: AnyLinkableHash::from(agent_address),
-    target_entry_hash: AnyLinkableHash::from(target),
+    source_entry_hash: source,
+    target_entry_hash: target,
     prefix,
     content,
     value,
@@ -243,7 +242,7 @@ pub fn get_extra(entry_hash: &EntryHash) -> ExternResult<Extra> {
     ))),
   }
 }
-
+#[allow(clippy::needless_pass_by_value)]
 pub fn query_mine(
   target: Option<AnyLinkableHash>,
   prefix: Option<String>,
@@ -268,7 +267,7 @@ pub fn query_mine(
 /// Required: exactly one of source or target
 /// All other arguments are optional
 /// Arguments act as additive filters (AND)
-#[warn(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value)]
 pub fn query(
   source: Option<AnyLinkableHash>,
   target: Option<AnyLinkableHash>,
@@ -363,6 +362,7 @@ pub fn query(
   Ok(trust_atoms)
 }
 
+#[allow(clippy::needless_pass_by_value)]
 pub fn convert_links_to_trust_atoms(
   links: Vec<Link>,
   link_direction: &LinkDirection,
@@ -379,7 +379,7 @@ pub fn convert_links_to_trust_atoms(
   //   Ok(trust_atoms.or_else(|_| WasmError::Guest("erro"))?)
 }
 
-// #[warn(clippy::pedantic)]
+#[allow(clippy::needless_pass_by_value)]
 pub(crate) fn convert_link_to_trust_atom(
   link: Link,
   link_direction: &LinkDirection,
@@ -398,7 +398,6 @@ pub(crate) fn convert_link_to_trust_atom(
   };
 
   let chunks: Vec<&str> = link_tag.split(UNICODE_NUL_STR).collect();
-  // debug!("chunks: {:?}", chunks);
 
   let prefix = {
     if chunks[1].is_empty() {
@@ -441,10 +440,8 @@ pub(crate) fn convert_link_to_trust_atom(
 
   let trust_atom = match link_direction {
     LinkDirection::Forward => TrustAtom {
-      // source: link_base_b64.to_string(),
-      // target: link_target_b64.to_string(),
-      source_entry_hash: AnyLinkableHash::from(link_base),
-      target_entry_hash: AnyLinkableHash::from(link.target),
+      source_entry_hash: link_base,
+      target_entry_hash: link.target,
       prefix,
       content,
       value,
@@ -452,8 +449,8 @@ pub(crate) fn convert_link_to_trust_atom(
     },
     LinkDirection::Reverse => {
       TrustAtom {
-        source_entry_hash: AnyLinkableHash::from(link.target), // flipped for Reverse direction
-        target_entry_hash: AnyLinkableHash::from(link_base),   // flipped for Reverse direction
+        source_entry_hash: link.target, // flipped for Reverse direction
+        target_entry_hash: link_base,   // flipped for Reverse direction
         prefix,
         content,
         value,

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -51,14 +51,7 @@ pub fn create_mine_trust_atom(
   extra: Option<BTreeMap<String, String>>,
 ) -> ExternResult<TrustAtom> {
   let me = AnyLinkableHash::from(agent_info()?.agent_latest_pubkey);
-  create_trust_atom(
-    me,
-    target,
-    prefix,
-    content,
-    value,
-    extra
-  )
+  create_trust_atom(me, target, prefix, content, value, extra)
 }
 
 pub fn create_trust_atom(

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -62,7 +62,6 @@ pub fn create_trust_atom(
   value: Option<String>,
   extra: Option<BTreeMap<String, String>>,
 ) -> ExternResult<TrustAtom> {
-
   let bucket = create_bucket()?;
 
   let extra_entry_hash_string = match extra.clone() {
@@ -92,7 +91,7 @@ pub fn create_trust_atom(
   )?;
   create_link(
     target.clone(),
-    SourceChainResult.clone(),
+    source.clone(),
     HdkLinkType::Any,
     reverse_link_tag,
   )?;

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -362,7 +362,7 @@ pub fn query(
     }
   };
   // debug!("links: {:?}", links);
-  let trust_atoms = convert_links_to_trust_atoms(links, &link_direction, &link_base)?;
+  let trust_atoms = convert_links_to_trust_atoms(links, &link_direction, link_base)?;
   Ok(trust_atoms)
 }
 
@@ -383,7 +383,7 @@ pub fn convert_links_to_trust_atoms(
 }
 
 // #[warn(clippy::pedantic)]
-fn convert_link_to_trust_atom(
+pub(crate) fn convert_link_to_trust_atom(
   link: Link,
   link_direction: &LinkDirection,
   link_base: AnyLinkableHash,

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -6,18 +6,21 @@ use hdk::prelude::*;
 use rust_decimal::prelude::*;
 use std::collections::BTreeMap;
 
+use crate::utils::try_get_element;
+
 #[derive(Debug, Clone)]
-enum LinkDirection {
+pub enum LinkDirection {
   Forward,
   Reverse,
 }
 
 /// Client-facing representation of a Trust Atom
 /// We may support JSON in the future to allow for more complex data structures @TODO
-#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct TrustAtom {
   pub source_entry_hash: AnyLinkableHashB64,
   pub target_entry_hash: AnyLinkableHashB64,
+  pub prefix: Option<String>,
   pub content: Option<String>,
   pub value: Option<String>,
   pub extra: Option<BTreeMap<String, String>>,
@@ -28,14 +31,22 @@ const LINK_TAG_HEADER: [u8; 2] = [197, 166]; // Unicode "Ŧ" // hex bytes: [0xC5
 const LINK_TAG_ARROW_FORWARD: [u8; 3] = [226, 134, 146]; // Unicode "→" // hex bytes: [0xE2][0x86][0x92]
 const LINK_TAG_ARROW_REVERSE: [u8; 3] = [226, 134, 169]; // Unicode "↩" // hex bytes: [0xE2][0x86][0xA9]
 
+// pub enum ExtraEntryInput {
+//   Content(String),
+//   SourcedAtoms(BTreeMap<EntryHashB64, TrustAtom>),
+//   Attributes(BTreeMap<String, String>),
+// }
+
 #[hdk_entry(id = "extra", visibility = "public")]
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Extra {
-  pub fields: BTreeMap<String, String>, // extra content
+  pub field: BTreeMap<String, String>,
 }
 
-pub fn create(
+pub fn create_trust_atom(
+  source: EntryHash, //// for tests ////
   target: AnyLinkableHash,
+  prefix: Option<String>,
   content: Option<String>,
   value: Option<String>,
   extra: Option<BTreeMap<String, String>>,
@@ -48,8 +59,8 @@ pub fn create(
     Some(x) => Some(create_extra(x)?),
     None => None,
   };
-
   let chunks = [
+    prefix.clone(),
     content.clone(),
     normalize_value(value.clone())?,
     Some(bucket),
@@ -57,6 +68,11 @@ pub fn create(
   ];
   let forward_link_tag = create_link_tag(&LinkDirection::Forward, &chunks);
   let reverse_link_tag = create_link_tag(&LinkDirection::Reverse, &chunks);
+
+  // debug!(
+  //   "forward_link_tag: {:?}",
+  //   String::from_utf8_lossy(&forward_link_tag.clone().into_inner())
+  // );
 
   create_link(
     agent_address.clone(),
@@ -74,10 +90,13 @@ pub fn create(
   let trust_atom = TrustAtom {
     source_entry_hash: AnyLinkableHashB64::from(agent_address),
     target_entry_hash: AnyLinkableHashB64::from(target),
+    prefix,
     content,
     value,
     extra,
   };
+
+  // debug!("atoms: {:#?}", trust_atom);
   Ok(trust_atom)
 }
 
@@ -95,19 +114,12 @@ fn create_bucket_string(bucket_bytes: &[u8]) -> String {
   bucket
 }
 
-fn create_extra(input: BTreeMap<String, String>) -> ExternResult<String> {
-  let entry = Extra { fields: input };
-
+pub fn create_extra(input: BTreeMap<String, String>) -> ExternResult<String> {
+  let entry = Extra { field: input };
   create_entry(entry.clone())?;
-
-  let entry_hash_string = calc_extra_hash(entry)?.to_string();
+  let entry_hash_string = hash_entry(entry)?.to_string();
   Ok(entry_hash_string)
-}
-
-pub fn calc_extra_hash(input: Extra) -> ExternResult<EntryHash> {
-  let hash = hash_entry(input)?;
-  Ok(hash)
-}
+} // returns stringified EntryHash
 
 fn normalize_value(value_str: Option<String>) -> ExternResult<Option<String>> {
   match value_str {
@@ -144,7 +156,11 @@ fn normalize_value(value_str: Option<String>) -> ExternResult<Option<String>> {
   }
 }
 
-fn create_link_tag(link_direction: &LinkDirection, chunk_options: &[Option<String>]) -> LinkTag {
+#[must_use]
+pub fn create_link_tag(
+  link_direction: &LinkDirection,
+  chunk_options: &[Option<String>],
+) -> LinkTag {
   let mut chunks: Vec<String> = vec![];
 
   for i in 0..chunk_options.len() {
@@ -155,7 +171,6 @@ fn create_link_tag(link_direction: &LinkDirection, chunk_options: &[Option<Strin
       chunks.push(UNICODE_NUL_STR.to_string());
     }
   }
-
   create_link_tag_metal(link_direction, chunks)
 }
 
@@ -168,21 +183,45 @@ fn create_link_tag_metal(link_direction: &LinkDirection, chunks: Vec<String>) ->
   let mut link_tag_bytes = vec![];
   link_tag_bytes.extend_from_slice(&LINK_TAG_HEADER);
   link_tag_bytes.extend_from_slice(&link_tag_arrow);
+  link_tag_bytes.extend_from_slice(UNICODE_NUL_STR.as_bytes());
 
   for chunk in chunks {
     link_tag_bytes.extend_from_slice(chunk.as_bytes());
   }
 
-  // debug!("link_tag: {:?}", String::from_utf8_lossy(&link_tag_bytes));
+  // debug!("link_tag_metal: {:?}", String::from_utf8_lossy(&link_tag_bytes));
   LinkTag(link_tag_bytes)
 }
 
+#[must_use]
+pub fn build_link_tag(
+  link_direction: &LinkDirection,
+  chunk_options: &[Option<String>],
+  nul_count: u8,
+) -> LinkTag {
+  let mut chunks: Vec<String> = vec![];
+  let mut count = 0;
+  while nul_count > count {
+    chunks.push(UNICODE_NUL_STR.to_string());
+    count += 1;
+  }
+  for i in 0..chunk_options.len() {
+    if let Some(chunk) = chunk_options[i].clone() {
+      chunks.push(chunk);
+    }
+    if i < chunk_options.len() - 1 {
+      chunks.push(UNICODE_NUL_STR.to_string());
+    }
+  }
+  create_link_tag_metal(link_direction, chunks)
+}
+
 pub fn get_extra(entry_hash: &EntryHash) -> ExternResult<Extra> {
-  let element = get_element(entry_hash, GetOptions::default())?;
+  let element = try_get_element(entry_hash, GetOptions::default())?;
   match element.entry() {
     element::ElementEntry::Present(entry) => {
       Extra::try_from(entry.clone()).or(Err(WasmError::Guest(format!(
-        "Couldn't convert Element entry {:?} into data type {}",
+        "Couldn't convert Element entry {:?} into data prefix {}",
         entry,
         std::any::type_name::<Extra>()
       ))))
@@ -194,18 +233,9 @@ pub fn get_extra(entry_hash: &EntryHash) -> ExternResult<Extra> {
   }
 }
 
-fn get_element(entry_hash: &EntryHash, get_options: GetOptions) -> ExternResult<Element> {
-  match get(entry_hash.clone(), get_options)? {
-    Some(element) => Ok(element),
-    None => Err(WasmError::Guest(format!(
-      "There is no element at the hash {}",
-      entry_hash
-    ))),
-  }
-}
-
 pub fn query_mine(
   target: Option<AnyLinkableHash>,
+  prefix: Option<String>,
   content_full: Option<String>,
   content_starts_with: Option<String>,
   value_starts_with: Option<String>,
@@ -214,7 +244,8 @@ pub fn query_mine(
 
   let result = query(
     Some(agent_address),
-    target,
+    None,
+    prefix,
     content_full,
     content_starts_with,
     value_starts_with,
@@ -230,6 +261,7 @@ pub fn query_mine(
 pub fn query(
   source: Option<AnyLinkableHash>,
   target: Option<AnyLinkableHash>,
+  prefix: Option<String>,
   content_full: Option<String>,
   content_starts_with: Option<String>,
   value_starts_with: Option<String>,
@@ -248,8 +280,12 @@ pub fn query(
       ))
     }
   };
+  // debug!("link_direction: {:?}", link_direction);
+  // debug!("link_base: {:?}", link_base);
 
-  let link_tag = match (content_full, content_starts_with, value_starts_with) {
+  let link_tag = match prefix {
+    Some(prefix) => {
+     match (content_full.clone(), content_starts_with, value_starts_with) {
     (Some(_content_full), Some(_content_starts_with), _) => {
       return Err(WasmError::Guest("Only one of `content_full` or `content_starts_with` can be used".into()))
     }
@@ -258,29 +294,65 @@ pub fn query(
         "Cannot use `value_starts_with` and `content_starts_with` arguments together; maybe try `content_full` instead?".into(),
       ))
     }
-    (Some(content_full), None, Some(value_starts_with)) => Some(create_link_tag(
+    (Some(content_full), None, Some(value_starts_with)) => Some(build_link_tag(
       &link_direction,
-      &[Some(content_full), Some(value_starts_with)],
+      &[Some(prefix), Some(content_full), Some(value_starts_with)], 0,
     )),
     (Some(content_full), None, None) => {
-      Some(create_link_tag_metal(&link_direction, vec![content_full, UNICODE_NUL_STR.to_string()]))
+      Some(build_link_tag(&link_direction, &[Some(prefix), Some(content_full)], 0))
     }
-    (None, Some(content_starts_with), None) => Some(create_link_tag(
+    (None, Some(content_starts_with), None) => Some(build_link_tag(
       &link_direction,
-      &[Some(content_starts_with)],
+      &[Some(prefix), Some(content_starts_with)], 0,
     )),
-    (None, None, Some(value_starts_with)) => Some(create_link_tag(&link_direction, &[Some(value_starts_with)])),
+    (None, None, Some(value_starts_with)) => Some(build_link_tag(&link_direction, &[Some(prefix), Some(value_starts_with)], 0)),
+    (None, None, None) => Some(build_link_tag(&link_direction, &[Some(prefix)], 0)),
+    }
+    }
+    None => {
+    match (content_full.clone(), content_starts_with, value_starts_with) {
+    (Some(_content_full), Some(_content_starts_with), _) => {
+      return Err(WasmError::Guest("Only one of `content_full` or `content_starts_with` can be used".into()))
+    }
+    (_, Some(_content_starts_with), Some(_value_starts_with)) => {
+      return Err(WasmError::Guest(
+        "Cannot use `value_starts_with` and `content_starts_with` arguments together; maybe try `content_full` instead?".into(),
+      ))
+    }
+    (Some(content_full), None, Some(value_starts_with)) => Some(build_link_tag(
+      &link_direction,
+      &[Some(content_full), Some(value_starts_with)], 1,
+    )),
+    (Some(content_full), None, None) => {
+      Some(build_link_tag(&link_direction, &[Some(content_full)], 1))
+    }
+    (None, Some(content_starts_with), None) => Some(build_link_tag(
+      &link_direction,
+      &[Some(content_starts_with)], 1
+    )),
+    (None, None, Some(value_starts_with)) => Some(build_link_tag(&link_direction, &[Some(value_starts_with)], 2)),
     (None, None, None) => None,
+    }
+    }
   };
-  let links = get_links(link_base.clone(), link_tag)?;
-
-  let trust_atoms = convert_links_to_trust_atoms(links, &link_direction, link_base)?;
-
+  // let link_tag_string = String::from_utf8(link_tag.clone().unwrap().into_inner());
+  // debug!("link_tag:  {:?}", link_tag_string);
+  let links = {
+    if content_full.is_some() {
+      let mut filter = link_tag.expect("Expected content").into_inner();
+      filter.extend_from_slice(UNICODE_NUL_STR.as_bytes());
+      // debug!("filter: {:?}", filter);
+      get_links(link_base.clone(), Some(LinkTag::from(filter)))?
+    } else {
+      get_links(link_base.clone(), link_tag)?
+    }
+  };
+  // debug!("links: {:?}", links);
+  let trust_atoms = convert_links_to_trust_atoms(links, &link_direction, &link_base)?;
   Ok(trust_atoms)
 }
 
-#[allow(clippy::needless_pass_by_value)]
-fn convert_links_to_trust_atoms(
+pub fn convert_links_to_trust_atoms(
   links: Vec<Link>,
   link_direction: &LinkDirection,
   link_base: AnyLinkableHash,
@@ -290,6 +362,7 @@ fn convert_links_to_trust_atoms(
     .map(|link| convert_link_to_trust_atom(link, link_direction, link_base.clone()))
     .collect();
   let trust_atoms = trust_atoms_result?;
+  // debug!("converted_TAs: {:?}", trust_atoms);
   Ok(trust_atoms)
   // .ok_or_else(|_| WasmError::Guest("Failure in converting links to trust atoms".to_string()))?;
   //   Ok(trust_atoms.or_else(|_| WasmError::Guest("erro"))?)
@@ -302,6 +375,7 @@ fn convert_link_to_trust_atom(
   link_base: AnyLinkableHash,
 ) -> ExternResult<TrustAtom> {
   let link_tag_bytes = link.tag.clone().into_inner();
+  // .split_off(tg_link_tag_header_length()); // drop leading "Ŧ→" or "Ŧ↩" // not needed if we add unicode nul after, see line 190
   let link_tag = match String::from_utf8(link_tag_bytes) {
     Ok(link_tag) => link_tag,
     Err(_) => {
@@ -313,169 +387,210 @@ fn convert_link_to_trust_atom(
   };
 
   let chunks: Vec<&str> = link_tag.split(UNICODE_NUL_STR).collect();
-  let content = chunks[0][tg_link_tag_header_length()..].to_string(); // drop leading "Ŧ→" or "Ŧ↩"
-  let value = chunks[1].to_string();
+  // debug!("chunks: {:?}", chunks);
 
-  let trust_atom = match link_direction {
-    LinkDirection::Forward => {
-      TrustAtom {
-        source_entry_hash: AnyLinkableHashB64::from(link_base),
-        target_entry_hash: AnyLinkableHashB64::from(link.target),
-        content: Some(content),
-        value: Some(value),
-        extra: Some(BTreeMap::new()), // TODO
+  let prefix = {
+    if chunks[1].is_empty() {
+      None
+    } else {
+      Some(chunks[1].to_string())
+    }
+  };
+
+  let content = {
+    if chunks[2].is_empty() {
+      None
+    } else {
+      Some(chunks[2].to_string())
+    }
+  };
+
+  let value = {
+    if chunks[3].is_empty() {
+      None
+    } else {
+      Some(chunks[3].to_string())
+    }
+  };
+  // bucket is chunk 4
+  let extra = {
+    if chunks[5].is_empty() {
+      None
+    } else {
+      let entry_hash = EntryHash::from_raw_39(chunks[5].to_string().into_bytes());
+      if let Ok(hash) = entry_hash {
+        Some(get_extra(&hash)?.field)
+      } else {
+        return Err(WasmError::Guest(
+          "could not convert hash string".to_string(),
+        ));
       }
     }
+  };
+
+  let trust_atom = match link_direction {
+    LinkDirection::Forward => TrustAtom {
+      // source: link_base_b64.to_string(),
+      // target: link_target_b64.to_string(),
+      source_entry_hash: AnyLinkableHashB64::from(link_base),
+      target_entry_hash: AnyLinkableHashB64::from(link.target),
+      prefix,
+      content,
+      value,
+      extra,
+    },
     LinkDirection::Reverse => {
       TrustAtom {
         source_entry_hash: AnyLinkableHashB64::from(link.target), // flipped for Reverse direction
         target_entry_hash: AnyLinkableHashB64::from(link_base),   // flipped for Reverse direction
-        content: Some(content),
-        value: Some(value),
-        extra: Some(BTreeMap::new()), // TODO
+        prefix,
+        content,
+        value,
+        extra,
       }
     }
   };
+  // debug!("converted_link: {:?}", trust_atom);
   Ok(trust_atom)
 }
 
-const fn tg_link_tag_header_length() -> usize {
-  LINK_TAG_HEADER.len() + LINK_TAG_ARROW_FORWARD.len()
-}
+// const fn tg_link_tag_header_length() -> usize {
+//   LINK_TAG_HEADER.len() + LINK_TAG_ARROW_FORWARD.len()
+// }
 
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-#[allow(non_snake_case)]
-mod tests {
+// #[cfg(test)]
+// #[allow(clippy::unwrap_used)]
+// #[allow(non_snake_case)]
+// mod tests {
 
-  use super::*; // allows testing of private functions
+//   use super::*; // allows testing of private functions
 
-  #[test]
-  fn test_normalize_value__valid_value() {
-    let valid_values = [
-      "1.0",
-      "1.000000000000000000000000000",
-      "1",
-      "0.534857395723489529357489283",
-      "0.0",
-      "0.000000000000000000000000000",
-      "0",
-      "-1.0",
-      "-1",
-      "-1.00000000000000000000000000",
-    ];
+//   #[test]
+//   fn test_normalize_value__valid_value() {
+//     let valid_values = [
+//       "1.0",
+//       "1.000000000000000000000000000",
+//       "1",
+//       "0.534857395723489529357489283",
+//       "0.0",
+//       "0.000000000000000000000000000",
+//       "0",
+//       "-1.0",
+//       "-1",
+//       "-1.00000000000000000000000000",
+//     ];
 
-    for value in valid_values {
-      normalize_value(Some(value.to_string())).unwrap();
-    }
-  }
+//     for value in valid_values {
+//       normalize_value(Some(value.to_string())).unwrap();
+//     }
+//   }
 
-  #[test]
-  fn test_normalize_value__values_out_of_range() {
-    let out_of_range_values = [
-      "100000000000000000",
-      "-100000000000000000",
-      "2",
-      "1.000000005",
-      "1.00000001",
-      "-1.00000001",
-      "-1.000000005",
-      "-2",
-    ];
+//   #[test]
+//   fn test_normalize_value__values_out_of_range() {
+//     let out_of_range_values = [
+//       "100000000000000000",
+//       "-100000000000000000",
+//       "2",
+//       "1.000000005",
+//       "1.00000001",
+//       "-1.00000001",
+//       "-1.000000005",
+//       "-2",
+//     ];
 
-    for value in out_of_range_values {
-      let expected_error_message = "Value must be in the range -1..1";
-      let actual_error_message = normalize_value(Some(value.to_string()))
-        .expect_err(&format!("expected error for value `{}`, got", value))
-        .to_string();
-      assert!(
-        actual_error_message.contains(expected_error_message),
-        "Expected error message: `...{}...`, but got: `{}`",
-        expected_error_message,
-        actual_error_message
-      );
-    }
-  }
+//     for value in out_of_range_values {
+//       let expected_error_message = "Value must be in the range -1..1";
+//       let actual_error_message = normalize_value(Some(value.to_string()))
+//         .expect_err(&format!("expected error for value `{}`, got", value))
+//         .to_string();
+//       assert!(
+//         actual_error_message.contains(expected_error_message),
+//         "Expected error message: `...{}...`, but got: `{}`",
+//         expected_error_message,
+//         actual_error_message
+//       );
+//     }
+//   }
 
-  #[test]
-  fn test_normalize_value__values_not_numeric() {
-    #[rustfmt::skip]
-    let non_numeric_values = [
-      " ",
-      " 0 ",
-      " 0",
-      "-.",
-      "-",
-      "-100000000000000000000000000000.0",
-      "-1e",
-      "-1e0",
-      "-e0",
-      "!",
-      ".",
-      "",
-      "",
-      "\u{1f9d0}",
-      "0 ",
-      "100000000000000000000000000000.0",
-      "1e",
-      "1e0",
-      "e",
-      "e0",
-      "foo",
-     ];
+//   #[test]
+//   fn test_normalize_value__values_not_numeric() {
+//     #[rustfmt::skip]
+//     let non_numeric_values = [
+//       " ",
+//       " 0 ",
+//       " 0",
+//       "-.",
+//       "-",
+//       "-100000000000000000000000000000.0",
+//       "-1e",
+//       "-1e0",
+//       "-e0",
+//       "!",
+//       ".",
+//       "",
+//       "",
+//       "\u{1f9d0}",
+//       "0 ",
+//       "100000000000000000000000000000.0",
+//       "1e",
+//       "1e0",
+//       "e",
+//       "e0",
+//       "foo",
+//      ];
 
-    for value in non_numeric_values {
-      let expected_error_message = "Value could not be processed";
-      let actual_error_message = normalize_value(Some(value.to_string()))
-        .expect_err(&format!("expected error for value `{}`, got", value))
-        .to_string();
-      assert!(
-        actual_error_message.contains(expected_error_message),
-        "Expected error message: `...{}...`, but got: `{}`",
-        expected_error_message,
-        actual_error_message
-      );
-    }
-  }
+//     for value in non_numeric_values {
+//       let expected_error_message = "Value could not be processed";
+//       let actual_error_message = normalize_value(Some(value.to_string()))
+//         .expect_err(&format!("expected error for value `{}`, got", value))
+//         .to_string();
+//       assert!(
+//         actual_error_message.contains(expected_error_message),
+//         "Expected error message: `...{}...`, but got: `{}`",
+//         expected_error_message,
+//         actual_error_message
+//       );
+//     }
+//   }
 
-  #[test]
-  fn test_normalize_value() {
-    let input_and_expected = [
-      ["-.9", "-.900000000"],
-      ["-.9000", "-.900000000"],
-      ["-.900000000", "-.900000000"],
-      ["-.9000000004", "-.900000000"],
-      ["-.9000000005", "-.900000001"],
-      ["-0.900000000", "-.900000000"],
-      ["0.8999999995", ".900000000"],
-      ["0.7999999995", ".800000000"],
-      ["-0.8999999995", "-.900000000"],
-      ["-0.7999999995", "-.800000000"],
-      ["0.8999999994", ".899999999"],
-      ["0.7999999994", ".799999999"],
-      ["-0.8999999994", "-.899999999"],
-      ["-0.7999999994", "-.799999999"],
-      [".9", ".900000000"],
-      [".9000", ".900000000"],
-      [".900000000", ".900000000"],
-      ["0.900000000", ".900000000"],
-      //
-      ["1", ".999999999"],
-      ["1.0", ".999999999"],
-      ["-1", "-.999999999"],
-      ["-1.0", "-.999999999"],
-    ];
+//   #[test]
+//   fn test_normalize_value() {
+//     let input_and_expected = [
+//       ["-.9", "-.900000000"],
+//       ["-.9000", "-.900000000"],
+//       ["-.900000000", "-.900000000"],
+//       ["-.9000000004", "-.900000000"],
+//       ["-.9000000005", "-.900000001"],
+//       ["-0.900000000", "-.900000000"],
+//       ["0.8999999995", ".900000000"],
+//       ["0.7999999995", ".800000000"],
+//       ["-0.8999999995", "-.900000000"],
+//       ["-0.7999999995", "-.800000000"],
+//       ["0.8999999994", ".899999999"],
+//       ["0.7999999994", ".799999999"],
+//       ["-0.8999999994", "-.899999999"],
+//       ["-0.7999999994", "-.799999999"],
+//       [".9", ".900000000"],
+//       [".9000", ".900000000"],
+//       [".900000000", ".900000000"],
+//       ["0.900000000", ".900000000"],
+//       //
+//       ["1", ".999999999"],
+//       ["1.0", ".999999999"],
+//       ["-1", "-.999999999"],
+//       ["-1.0", "-.999999999"],
+//     ];
 
-    for [input, expected] in input_and_expected {
-      let normalized_value = normalize_value(Some(input.to_string())).unwrap().unwrap();
-      assert_eq!(normalized_value, expected.to_string());
-    }
-  }
+//     for [input, expected] in input_and_expected {
+//       let normalized_value = normalize_value(Some(input.to_string())).unwrap().unwrap();
+//       assert_eq!(normalized_value, expected.to_string());
+//     }
+//   }
 
-  #[test]
-  fn test_bucket_val() {
-    let bytes: [u8; 9] = [9, 10, 11, 12, 13, 14, 15, 16, 17];
-    let bucket = create_bucket_string(&bytes);
-    assert_eq!(bucket, "901234567".to_string());
-  }
-}
+//   #[test]
+//   fn test_bucket_val() {
+//     let bytes: [u8; 9] = [9, 10, 11, 12, 13, 14, 15, 16, 17];
+//     let bucket = create_bucket_string(&bytes);
+//     assert_eq!(bucket, "901234567".to_string());
+//   }
+// }

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use ::holo_hash::AnyLinkableHash;
-use ::holo_hash::AnyLinkableHashB64;
+// use ::holo_hash::AnyLinkableHashB64;
 use hdk::prelude::*;
 use rust_decimal::prelude::*;
 use std::collections::BTreeMap;
@@ -18,8 +18,8 @@ pub enum LinkDirection {
 /// We may support JSON in the future to allow for more complex data structures @TODO
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct TrustAtom {
-  pub source_entry_hash: AnyLinkableHashB64,
-  pub target_entry_hash: AnyLinkableHashB64,
+  pub source_entry_hash: AnyLinkableHash,
+  pub target_entry_hash: AnyLinkableHash,
   pub prefix: Option<String>,
   pub content: Option<String>,
   pub value: Option<String>,
@@ -102,8 +102,8 @@ pub fn create_trust_atom(
   )?;
 
   let trust_atom = TrustAtom {
-    source_entry_hash: AnyLinkableHashB64::from(agent_address),
-    target_entry_hash: AnyLinkableHashB64::from(target),
+    source_entry_hash: AnyLinkableHash::from(agent_address),
+    target_entry_hash: AnyLinkableHash::from(target),
     prefix,
     content,
     value,
@@ -446,8 +446,8 @@ pub(crate) fn convert_link_to_trust_atom(
     LinkDirection::Forward => TrustAtom {
       // source: link_base_b64.to_string(),
       // target: link_target_b64.to_string(),
-      source_entry_hash: AnyLinkableHashB64::from(link_base),
-      target_entry_hash: AnyLinkableHashB64::from(link.target),
+      source_entry_hash: AnyLinkableHash::from(link_base),
+      target_entry_hash: AnyLinkableHash::from(link.target),
       prefix,
       content,
       value,
@@ -455,8 +455,8 @@ pub(crate) fn convert_link_to_trust_atom(
     },
     LinkDirection::Reverse => {
       TrustAtom {
-        source_entry_hash: AnyLinkableHashB64::from(link.target), // flipped for Reverse direction
-        target_entry_hash: AnyLinkableHashB64::from(link_base),   // flipped for Reverse direction
+        source_entry_hash: AnyLinkableHash::from(link.target), // flipped for Reverse direction
+        target_entry_hash: AnyLinkableHash::from(link_base),   // flipped for Reverse direction
         prefix,
         content,
         value,

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -43,19 +43,23 @@ pub struct Extra {
   pub field: BTreeMap<String, String>,
 }
 
-// pub fn create_trust_atom(
-//   source: EntryHash, //// for tests ////
-//   target: AnyLinkableHash,
-//   prefix: Option<String>,
-//   content: Option<String>,
-//   value: Option<String>,
-//   extra: Option<BTreeMap<String, String>>,
-// ) -> ExternResult<TrustAtom> {
-// set source to me
-// create_trust_atom(
-// source: me
-// ...
-// )
+pub fn create_mine_trust_atom(
+  target: AnyLinkableHash,
+  prefix: Option<String>,
+  content: Option<String>,
+  value: Option<String>,
+  extra: Option<BTreeMap<String, String>>,
+) -> ExternResult<TrustAtom> {
+  let me = AnyLinkableHash::from(agent_info()?.agent_latest_pubkey);
+  create_trust_atom(
+    me,
+    target,
+    prefix,
+    content,
+    value,
+    extra
+  )
+}
 
 pub fn create_trust_atom(
   source: AnyLinkableHash,
@@ -65,7 +69,7 @@ pub fn create_trust_atom(
   value: Option<String>,
   extra: Option<BTreeMap<String, String>>,
 ) -> ExternResult<TrustAtom> {
-  let agent_address = AnyLinkableHash::from(agent_info()?.agent_initial_pubkey);
+  let agent_address = AnyLinkableHash::from(source);
 
   let bucket = create_bucket()?;
 

--- a/zomes/hc_zome_trust_atom/src/trust_atom.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_atom.rs
@@ -43,7 +43,21 @@ pub struct Extra {
   pub field: BTreeMap<String, String>,
 }
 
-pub fn create_trust_atom(
+// pub fn create_trust_atom(
+//   source: EntryHash, //// for tests ////
+//   target: AnyLinkableHash,
+//   prefix: Option<String>,
+//   content: Option<String>,
+//   value: Option<String>,
+//   extra: Option<BTreeMap<String, String>>,
+// ) -> ExternResult<TrustAtom> {
+// set source to me
+// _create_trust_atom(
+// source: me
+// ...
+// )
+
+pub fn _create_trust_atom(
   source: EntryHash, //// for tests ////
   target: AnyLinkableHash,
   prefix: Option<String>,

--- a/zomes/hc_zome_trust_atom/src/trust_graph.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_graph.rs
@@ -4,7 +4,7 @@ use hdk::prelude::*;
 use std::collections::BTreeMap;
 
 use crate::trust_atom::{
-  _create_trust_atom, convert_link_to_trust_atom, convert_links_to_trust_atoms, create_link_tag,
+  convert_link_to_trust_atom, convert_links_to_trust_atoms, create_link_tag, create_trust_atom,
   query_mine, LinkDirection, TrustAtom,
 };
 
@@ -165,7 +165,7 @@ fn build_rollup_gold(
     if let Some(rating) = my_rating {
       let parsed: f64 = rating.parse::<f64>().expect("Parse Error");
       let algo: f64 = (weighted_sum - parsed).mul_add(0.20, parsed); // self weight is 80%
-      let rollup_atom = _create_trust_atom(
+      let rollup_atom = create_trust_atom(
         me.clone(),
         target.clone(),
         Some("rollup".to_string()),
@@ -180,7 +180,7 @@ fn build_rollup_gold(
       let total = accumulator.len() as f64;
 
       let algo: f64 = weighted_sum / total;
-      let rollup_atom = _create_trust_atom(
+      let rollup_atom = create_trust_atom(
         me.clone(),
         target.clone(),
         Some("rollup".to_string()),

--- a/zomes/hc_zome_trust_atom/src/trust_graph.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_graph.rs
@@ -51,10 +51,7 @@ fn build_rollup_silver(
 ) -> ExternResult<BTreeMap<AnyLinkableHash, BTreeMap<AnyLinkableHash, RollupData>>> {
   let mut rollup_silver: BTreeMap<AnyLinkableHash, BTreeMap<AnyLinkableHash, RollupData>> =
     BTreeMap::new(); // K: Target (AnyLinkableHash) V: BTreeMap<Agent, RollupData>
-  let targets: Vec<AnyLinkableHash> = atoms
-    .into_iter()
-    .map(|x| x.target_entry_hash)
-    .collect();
+  let targets: Vec<AnyLinkableHash> = atoms.into_iter().map(|x| x.target_entry_hash).collect();
 
   for target in targets.clone() {
     if target != me && !agents.contains(&target) {

--- a/zomes/hc_zome_trust_atom/src/trust_graph.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_graph.rs
@@ -1,0 +1,283 @@
+use hdk::prelude::holo_hash::EntryHashB64;
+use hdk::prelude::*;
+
+use std::collections::BTreeMap;
+
+use crate::trust_atom::{
+  convert_link_to_trust_atom, convert_links_to_trust_atoms, create_link_tag, create_trust_atom,
+  query_mine, LinkDirection, TrustAtom,
+};
+
+#[derive(Clone, Debug)]
+struct RollupData {
+  content: String,
+  value: String,
+  agent_rating: Option<String>,
+}
+
+pub fn create_rollup_atoms() -> ExternResult<Vec<TrustAtom>> {
+  let me: EntryHash = EntryHash::from(agent_info()?.agent_latest_pubkey);
+  let my_atoms: Vec<TrustAtom> = query_mine(None, None, None, None)?;
+  let agents = build_agent_list(my_atoms.clone())?;
+
+  let rollup_silver: BTreeMap<EntryHash, BTreeMap<EntryHash, RollupData>> =
+    build_rollup_silver(&me, my_atoms, agents)?;
+  let rollup_gold: Vec<TrustAtom> = build_rollup_gold(rollup_silver, me)?;
+  Ok(rollup_gold)
+}
+
+fn build_agent_list(atoms: Vec<TrustAtom>) -> ExternResult<Vec<EntryHash>> {
+  let mut agents: Vec<EntryHash> = Vec::new();
+
+  let chunks = [Some("rollup".to_string())];
+  let filter = create_link_tag(&LinkDirection::Forward, &chunks);
+
+  for ta in atoms {
+    let entry_hash = EntryHash::from(ta.target_entry_hash);
+    let rollup_links: Vec<Link> = get_links(entry_hash.clone(), Some(filter.clone()))?; // NOTE: Agent must have done at least one rollup
+    if !rollup_links.is_empty() && !agents.contains(&entry_hash) {
+      // prevent duplicates
+      agents.push(entry_hash);
+    }
+  }
+  Ok(agents)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn build_rollup_silver(
+  me: &EntryHash,
+  atoms: Vec<TrustAtom>,
+  agents: Vec<EntryHash>,
+) -> ExternResult<BTreeMap<EntryHash, BTreeMap<EntryHash, RollupData>>> {
+  let mut rollup_silver: BTreeMap<EntryHash, BTreeMap<EntryHash, RollupData>> = BTreeMap::new(); // K: Target (EntryHash) V: BTreeMap<Agent, RollupData>
+  let targets: Vec<EntryHash> = atoms
+    .into_iter()
+    .map(|x| EntryHash::from(x.target_entry_hash))
+    .collect();
+
+  for target in targets.clone() {
+    if &target != me && !agents.contains(&target) {
+      let links = get_links(target.clone(), None)?;
+      let mut links_latest = Vec::new();
+      for link in links.clone() {
+        let latest = get_latest(&target, &link.target, None)?;
+        if let Some(latest) = latest {
+          if !links_latest.contains(&latest) {
+            // debug!("latest: {:?}", latest);
+            links_latest.push(latest);
+          }
+        }
+      }
+      let trust_atoms_latest =
+        convert_links_to_trust_atoms(links_latest, &LinkDirection::Reverse, &target)?;
+      let mut map: BTreeMap<EntryHash, RollupData> = BTreeMap::new();
+      for ta in trust_atoms_latest.clone() {
+        let source = EntryHash::from(ta.source_entry_hash);
+        if agents.contains(&source) {
+          // get only Agent TAs
+          if let Some(content) = ta.content {
+            if let Some(value) = ta.value {
+              // ignore content without a rating
+
+              let chunks = [None, Some(content.clone())];
+
+              let filter = create_link_tag(&LinkDirection::Forward, &chunks); // NOTE: filter by content broken if mislabeled
+              let agent_rating: Option<String> = get_rating(me, &source, Some(filter))?;
+              if let Some(rating) = agent_rating {
+                let rating_ok = match rating.parse::<f64>() {
+                  Ok(r) => r,
+                  Err(_) => return Err(WasmError::Guest("failed to parse".to_string())),
+                };
+                if rating_ok > 0.0 {
+                  // retain only positively rated agents
+                  let rollup_data = RollupData {
+                    content,
+                    value,
+                    agent_rating: Some(rating),
+                  };
+                  map.insert(source.clone(), rollup_data);
+                }
+              }
+            }
+          }
+        }
+      }
+      rollup_silver.insert(target, map);
+    }
+  }
+  Ok(rollup_silver)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn build_rollup_gold(
+  rollup_silver: BTreeMap<EntryHash, BTreeMap<EntryHash, RollupData>>,
+  me: EntryHash,
+) -> ExternResult<Vec<TrustAtom>> {
+  let mut rollup_gold: Vec<TrustAtom> = Vec::new();
+  for (target, map) in rollup_silver.clone() {
+    let mut sourced_trust_atoms: BTreeMap<String, String> = BTreeMap::new(); // collect to input for rollup extra field
+    let mut accumulator: Vec<f64> = Vec::new(); // gather weighted values
+    let mut agent_rating_phi_sum: f64 = 0.0; // raised to PHI allows for smooth weight curve
+                                             // debug!("map: {:#?}", map);
+    for (agent, rollup_data) in map.clone() {
+      // debug!("data: {:#?}", rollup_data);
+      if let Some(rating) = rollup_data.agent_rating {
+        agent_rating_phi_sum += rating.parse::<f64>().expect("Parse Error").powf(1.618);
+      }
+      let link_latest = get_latest(&agent, &target, None)?;
+      if let Some(latest) = link_latest {
+        let sourced_atom_latest =
+          convert_link_to_trust_atom(latest, &LinkDirection::Forward, &agent)?;
+        sourced_trust_atoms.insert(
+          sourced_atom_latest.source_entry_hash.to_string(),
+          sourced_atom_latest.target_entry_hash.to_string(),
+        );
+      }
+    }
+    let sourced_atoms: Option<BTreeMap<String, String>> = {
+      if sourced_trust_atoms.is_empty() {
+        Some(sourced_trust_atoms)
+      } else {
+        None
+      }
+    };
+
+    for (_agent, rollup_data) in map.clone() {
+      if let Some(rating) = rollup_data.agent_rating {
+        let calc: f64 = (rating.parse::<f64>().expect("Parse Error").powf(1.618)
+          / agent_rating_phi_sum)
+          * rollup_data.value.parse::<f64>().expect("Parse Error");
+        accumulator.push(calc);
+      }
+    }
+
+    let my_rating: Option<String> = get_rating(&me, &target, None)?;
+    let weighted_sum: f64 = accumulator.iter().sum();
+    let content: Option<String> = {
+      // TODO: cleanup get content method by adding TA.target_name String
+      let get_latest = get_latest(&me, &target, None)?;
+      match get_latest {
+        Some(link) => convert_link_to_trust_atom(link, &LinkDirection::Forward, &me)?.content,
+        None => None,
+      }
+    };
+    if let Some(rating) = my_rating {
+      let parsed: f64 = rating.parse::<f64>().expect("Parse Error");
+      let algo: f64 = (weighted_sum - parsed).mul_add(0.20, parsed); // self weight is 80%
+      let rollup_atom = create_trust_atom(
+        me.clone(),
+        target.clone(),
+        Some("rollup".to_string()),
+        content.clone(),
+        Some(algo.to_string()),
+        None, //sourced_atoms.clone(),
+      )?;
+      rollup_gold.push(rollup_atom);
+    } else {
+      #[allow(clippy::pedantic)]
+      // if no self rating for target then avg the other agents weighted values
+      let total = accumulator.len() as f64;
+
+      let algo: f64 = weighted_sum / total;
+      let rollup_atom = create_trust_atom(
+        me.clone(),
+        target.clone(),
+        Some("rollup".to_string()),
+        content.clone(),
+        Some(algo.to_string()),
+        sourced_atoms.clone(),
+      )?;
+      rollup_gold.push(rollup_atom);
+    }
+  }
+  Ok(rollup_gold)
+}
+
+fn get_rating(
+  base: &EntryHash,
+  target: &EntryHash,
+  tag_filter: Option<LinkTag>,
+) -> ExternResult<Option<String>> {
+  let link_latest = get_latest(base, target, tag_filter)?;
+  if let Some(latest) = link_latest {
+    let trust_atom_latest = convert_link_to_trust_atom(latest, &LinkDirection::Forward, base)?;
+    // debug!("latest rating: {:?}", trust_atom_latest.value);
+    return Ok(trust_atom_latest.value);
+  }
+  Ok(None)
+}
+
+fn get_latest(
+  base: &EntryHash,
+  target: &EntryHash,
+  tag_filter: Option<LinkTag>,
+) -> ExternResult<Option<Link>> {
+  let mut links: Vec<Link> = get_links(base.clone(), tag_filter)?
+    .into_iter()
+    .filter(|x| x.target == *target)
+    .collect();
+  // debug!("get_latest_inks: {:?}", links);
+  links.sort_by(|a, b| a.timestamp.cmp(&b.timestamp)); // ignoring nanoseconds
+  let latest = links.pop();
+  // debug!("latest: {:?}", latest);
+  match latest {
+    Some(link) => Ok(Some(link)),
+    None => Ok(None),
+  }
+}
+
+// fn create_rollup_atoms() {
+
+// rollup_bronze: map = {
+//     HIA Entry hash (target): [  // target from my TAs or the rollups of agents in my TG
+//
+//         {
+//             // trust atom:
+//             source: zippy
+//             value: float
+//             content: holochain
+
+//            // plus my rating of the "source" agent
+//             agent_rating: float // my rating of zippy on `holochain`
+//         }
+//     ]
+//  }
+
+// rollup_silver: map = {
+//     HIA Entry hash (target): [  // target from my TAs or the rollups of agents in my TG
+//         {
+//             content: [
+//                 // latest rating by given agent:
+//                  {
+//                     source: zippy
+//                     value: float
+//                     // plus my rating of the "source" agent:
+//                     agent_rating: float // my rating of zippy on `holochain`
+//               }
+//           ]
+//        }
+//     ]
+//  }
+
+// gold:
+// rollup_gold: vec<TrustAtom>  = [
+//     {
+//       source: me
+//       type: rollup
+//       target: HIA Entry hash:
+//       value: float
+//       content: holochain
+//     }
+// ]
+
+// for item in rollup_gold:
+//      create_link for each
+
+// }
+
+// ALTERNATE STRATEGY (no agent registry, no ablity to identify whether entry is agentpubkey)
+
+// for TA in my TAs
+//   rollup_links = get_links(source: TA.target, type: "rollup")  // returns rollups from agents who have done rollups, but [] from non-agent entries
+//
+//

--- a/zomes/hc_zome_trust_atom/src/trust_graph.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_graph.rs
@@ -33,7 +33,7 @@ fn build_agent_list(atoms: Vec<TrustAtom>) -> ExternResult<Vec<AnyLinkableHash>>
   let filter = create_link_tag(&LinkDirection::Forward, &chunks);
 
   for ta in atoms {
-    let entry_hash = AnyLinkableHash::from(ta.target_entry_hash);
+    let entry_hash = ta.target_entry_hash;
     let rollup_links: Vec<Link> = get_links(entry_hash.clone(), Some(filter.clone()))?; // NOTE: Agent must have done at least one rollup
     if !rollup_links.is_empty() && !agents.contains(&entry_hash) {
       // prevent duplicates
@@ -53,7 +53,7 @@ fn build_rollup_silver(
     BTreeMap::new(); // K: Target (AnyLinkableHash) V: BTreeMap<Agent, RollupData>
   let targets: Vec<AnyLinkableHash> = atoms
     .into_iter()
-    .map(|x| AnyLinkableHash::from(x.target_entry_hash))
+    .map(|x| x.target_entry_hash)
     .collect();
 
   for target in targets.clone() {
@@ -73,7 +73,7 @@ fn build_rollup_silver(
         convert_links_to_trust_atoms(links_latest, &LinkDirection::Reverse, target.clone())?;
       let mut map: BTreeMap<AnyLinkableHash, RollupData> = BTreeMap::new();
       for ta in trust_atoms_latest.clone() {
-        let source = AnyLinkableHash::from(ta.source_entry_hash);
+        let source = ta.source_entry_hash;
         if agents.contains(&source) {
           // get only Agent TAs
           if let Some(content) = ta.content {
@@ -210,13 +210,13 @@ fn get_rating(
   }
   Ok(None)
 }
-
+#[allow(clippy::needless_pass_by_value)]
 fn get_latest(
   base: AnyLinkableHash,
   target: AnyLinkableHash,
   tag_filter: Option<LinkTag>,
 ) -> ExternResult<Option<Link>> {
-  let mut links: Vec<Link> = get_links(base.clone(), tag_filter)?
+  let mut links: Vec<Link> = get_links(base, tag_filter)?
     .into_iter()
     .filter(|x| x.target == target)
     .collect();

--- a/zomes/hc_zome_trust_atom/src/trust_graph.rs
+++ b/zomes/hc_zome_trust_atom/src/trust_graph.rs
@@ -1,4 +1,4 @@
-use hdk::prelude::holo_hash::EntryHashB64;
+use ::holo_hash::AnyLinkableHash;
 use hdk::prelude::*;
 
 use std::collections::BTreeMap;
@@ -83,7 +83,8 @@ fn build_rollup_silver(
               let chunks = [None, Some(content.clone())];
 
               let filter = create_link_tag(&LinkDirection::Forward, &chunks); // NOTE: filter by content broken if mislabeled
-              let agent_rating: Option<String> = get_rating(me.clone(), source.clone(), Some(filter))?;
+              let agent_rating: Option<String> =
+                get_rating(me.clone(), source.clone(), Some(filter))?;
               if let Some(rating) = agent_rating {
                 let rating_ok = match rating.parse::<f64>() {
                   Ok(r) => r,
@@ -158,7 +159,9 @@ fn build_rollup_gold(
       // TODO: cleanup get content method by adding TA.target_name String
       let get_latest = get_latest(me.clone(), target.clone(), None)?;
       match get_latest {
-        Some(link) => convert_link_to_trust_atom(link, &LinkDirection::Forward, me.clone())?.content,
+        Some(link) => {
+          convert_link_to_trust_atom(link, &LinkDirection::Forward, me.clone())?.content
+        }
         None => None,
       }
     };

--- a/zomes/hc_zome_trust_atom/src/utils.rs
+++ b/zomes/hc_zome_trust_atom/src/utils.rs
@@ -1,0 +1,11 @@
+use hdk::prelude::*;
+
+pub fn try_get_element(entry_hash: &EntryHash, get_options: GetOptions) -> ExternResult<Element> {
+  match get(entry_hash.clone(), get_options)? {
+    Some(element) => Ok(element),
+    None => Err(WasmError::Guest(format!(
+      "There is no element at the hash {}",
+      entry_hash
+    ))),
+  }
+}

--- a/zomes/hc_zome_trust_atom/tests/trust_atom_tests.rs
+++ b/zomes/hc_zome_trust_atom/tests/trust_atom_tests.rs
@@ -55,8 +55,8 @@ pub async fn test_create_trust_atom() {
   )]);
 
   let trust_atom_input = TrustAtomInput {
-source: EntryHash::from(agent.clone()),
-target: AnyLinkableHash::from(target_entry_hash.clone()),
+    source: EntryHash::from(agent.clone()),
+    target: AnyLinkableHash::from(target_entry_hash.clone()),
     prefix: None,
     content: Some(content.clone()),
     value: Some(value.clone()),
@@ -294,8 +294,8 @@ pub async fn test_query_mine() {
       &cell1.zome("trust_atom"),
       "create_trust_atom",
       TrustAtomInput {
-source: agent.clone().into(),
-target: AnyLinkableHash::from(target_entry_hash.clone()),
+        source: agent.clone().into(),
+        target: AnyLinkableHash::from(target_entry_hash.clone()),
         prefix: None,
         content: Some("sushi".to_string()),
         value: Some("0.8".to_string()),
@@ -332,9 +332,9 @@ target: AnyLinkableHash::from(target_entry_hash.clone()),
   assert_eq!(
     *trust_atom,
     TrustAtom {
-source_entry_hash: AnyLinkableHashB64::from(AnyLinkableHash::from(agent.clone())),
-target_entry_hash: AnyLinkableHashB64::from(AnyLinkableHash::from(target_entry_hash)),
-prefix: None,
+      source_entry_hash: AnyLinkableHashB64::from(AnyLinkableHash::from(agent.clone())),
+      target_entry_hash: AnyLinkableHashB64::from(AnyLinkableHash::from(target_entry_hash)),
+      prefix: None,
       content: Some("sushi".to_string()),
       value: Some(".800000000".to_string()),
       extra: None,
@@ -366,8 +366,8 @@ pub async fn test_query_mine_with_content_starts_with() {
         &cell1.zome("trust_atom"),
         "create_trust_atom",
         TrustAtomInput {
-source: agent.clone().into(),
-target: AnyLinkableHash::from(target_entry_hash.clone()),
+          source: agent.clone().into(),
+          target: AnyLinkableHash::from(target_entry_hash.clone()),
           prefix: None,
           content: Some(content.into()),
           value: Some("0.8".into()),
@@ -432,8 +432,8 @@ pub async fn test_query_mine_with_content_full() {
         &cell1.zome("trust_atom"),
         "create_trust_atom",
         TrustAtomInput {
-source: agent.clone().into(),
-target: AnyLinkableHash::from(target_entry_hash.clone()),
+          source: agent.clone().into(),
+          target: AnyLinkableHash::from(target_entry_hash.clone()),
           prefix: None,
           content: Some(content_full.into()),
           value: Some("0.8".into()),
@@ -518,31 +518,6 @@ pub async fn test_get_extra() {
       mock_extra_entry_hash,
     )
     .await;
-
-// <<<<<<< HEAD
-  let field1 = mock_extra_data
-    .fields
-    .get_key_value(&"extra_stuff".to_string())
-    .unwrap();
-  let field2 = mock_extra_data
-    .fields
-    .get_key_value(&"another_thing".to_string())
-    .unwrap();
-
-  assert_eq!(
-    field1,
-    (
-      &"extra_stuff".to_string(),
-      &"Say some extra stuff here".to_string()
-    )
-  );
-  assert_eq!(
-    field2,
-    (
-      &"another_thing".to_string(),
-      &"Put more information here".to_string()
-    )
-  );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -599,13 +574,14 @@ pub async fn test_get_entry_by_headerhash() {
 //   assert_eq!(mock_trust_atom, fetched_atom);
 //   assert_eq!(fetched_atom.target, ipfs_address);
 // }
+
 // =======
 // =======
 // =======
 // =======
-  assert_eq!(extra_map, mock_extra_data.clone().field);
-  assert_eq!(mock_extra_data.clone(), mock_entry.clone());
-}
+//   assert_eq!(extra_map, mock_extra_data.clone().field);
+//   assert_eq!(mock_extra_data.clone(), mock_entry.clone());
+// }
 
 #[tokio::test(flavor = "multi_thread")]
 pub async fn test_create_trust_atom_with_empty_chunks() {


### PR DESCRIPTION
fixes #25 and #28 

TrustGraph Zome creates rollup of Trust Atoms 2 levels deep (self + other agents whom you placed TA)

first builds agent list by identifying which targets have done a rollup (indicating they are an agent)
then rollup_silver returns BTreemap structure...  Key: Target (AnyLinkableHash) V: BTreeMap<Agent, RollupData>
where RollupData contains content value and agent's rating
then rollup_gold calculates an amalgamation of the targets those agents have rated (latest ie most recent update) thus "rolling up" a net value per each, returning a Vec<TrustAtom>

algorithm is now slightly weighted higher by the curve x^phi
