### PR TITLE
Split types into separate crate:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6103,6 +6103,7 @@ dependencies = [
  "serde",
  "tokio",
  "trust_atom_integrity",
+ "trust_atom_types",
 ]
 
 [[package]]
@@ -6111,6 +6112,14 @@ version = "0.1.1-dev"
 dependencies = [
  "hdi",
  "rust_decimal",
+ "serde",
+]
+
+[[package]]
+name = "trust_atom_types"
+version = "0.1.1-dev"
+dependencies = [
+ "hdk",
  "serde",
 ]
 

--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
       },
       "locked": {
         "dir": "versions/0_1",
-        "lastModified": 1679033847,
-        "narHash": "sha256-UD3eYcgSNR3w3Pwd7Lw/0nWD/9eiBl4cSHemSLZuWvo=",
+        "lastModified": 1679120250,
+        "narHash": "sha256-0vIMymVXxSmmHR8F9zAeReXg+03v+EqvkRKwUKfPcFI=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "293bad373aabd537285f92d69ca58aa377782bf7",
+        "rev": "41c10ffebe0e92858b40e182b36b5cdf175d4646",
         "type": "github"
       },
       "original": {

--- a/zomes/trust_atom/Cargo.toml
+++ b/zomes/trust_atom/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 hdk = "=0.1.1"
 rust_decimal = "1"
 serde = "1"
+trust_atom_types = { path = "../trust_atom_types" }
 trust_atom_integrity = { path = "../trust_atom_integrity" }
 
 [dev-dependencies]

--- a/zomes/trust_atom/src/lib.rs
+++ b/zomes/trust_atom/src/lib.rs
@@ -11,38 +11,11 @@
 // #![warn(clippy::cargo)]
 
 use hdk::prelude::*;
-use std::collections::BTreeMap;
 mod trust_atom;
 pub use crate::trust_atom::TrustAtom;
 pub(crate) use trust_atom_integrity::{Example, Extra};
+pub(crate) use trust_atom_types::{QueryInput, QueryMineInput, TrustAtomInput};
 pub(crate) mod test_helpers;
-
-// INPUT TYPES
-
-#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
-pub struct TrustAtomInput {
-  pub target: AnyLinkableHash,
-  pub content: Option<String>,
-  pub value: Option<String>,
-  pub extra: Option<BTreeMap<String, String>>,
-}
-
-#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
-pub struct QueryInput {
-  pub source: Option<AnyLinkableHash>,
-  pub target: Option<AnyLinkableHash>,
-  pub content_full: Option<String>,
-  pub content_starts_with: Option<String>,
-  pub value_starts_with: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
-pub struct QueryMineInput {
-  pub target: Option<AnyLinkableHash>,
-  pub content_full: Option<String>,
-  pub content_starts_with: Option<String>,
-  pub value_starts_with: Option<String>,
-}
 
 // ZOME API FUNCTIONS
 

--- a/zomes/trust_atom/tests/trust_atom_tests.rs
+++ b/zomes/trust_atom/tests/trust_atom_tests.rs
@@ -43,7 +43,7 @@ pub async fn test_create_trust_atom() {
       .into(),
   )]);
 
-  let trust_atom_input = trust_atom::TrustAtomInput {
+  let trust_atom_input = trust_atom_types::TrustAtomInput {
     target: AnyLinkableHash::from(target_hash.clone()),
     content: Some(content.clone()),
     value: Some(value.clone()),
@@ -163,7 +163,7 @@ pub async fn test_create_trust_atom_with_empty_chunks() {
 
   // CREATE TRUST ATOM
 
-  let trust_atom_input = trust_atom::TrustAtomInput {
+  let trust_atom_input = trust_atom_types::TrustAtomInput {
     target: AnyLinkableHash::from(target_hash.clone()),
     content: None,
     value: None,
@@ -266,7 +266,7 @@ pub async fn test_query_mine() {
     .call(
       &cell1.zome("trust_atom"),
       "create_trust_atom",
-      trust_atom::TrustAtomInput {
+      trust_atom_types::TrustAtomInput {
         target: AnyLinkableHash::from(target_hash.clone()),
         content: Some("sushi".to_string()),
         value: Some("0.8".to_string()),
@@ -284,7 +284,7 @@ pub async fn test_query_mine() {
     .call(
       &cell1.zome("trust_atom"),
       "query_mine",
-      trust_atom::QueryMineInput {
+      trust_atom_types::QueryMineInput {
         target: None,
         content_starts_with: None,
         content_full: None,
@@ -334,7 +334,7 @@ pub async fn test_query_mine_with_content_starts_with() {
       .call(
         &cell1.zome("trust_atom"),
         "create_trust_atom",
-        trust_atom::TrustAtomInput {
+        trust_atom_types::TrustAtomInput {
           target: AnyLinkableHash::from(target_hash.clone()),
           content: Some(content.into()),
           value: Some("0.8".into()),
@@ -349,7 +349,7 @@ pub async fn test_query_mine_with_content_starts_with() {
     .call(
       &cell1.zome("trust_atom"),
       "query_mine",
-      trust_atom::QueryMineInput {
+      trust_atom_types::QueryMineInput {
         target: None,
         content_full: None,
         content_starts_with: Some("sushi".into()),
@@ -397,7 +397,7 @@ pub async fn test_query_mine_with_content_full() {
       .call(
         &cell1.zome("trust_atom"),
         "create_trust_atom",
-        trust_atom::TrustAtomInput {
+        trust_atom_types::TrustAtomInput {
           target: AnyLinkableHash::from(target_hash.clone()),
           content: Some(content_full.into()),
           value: Some("0.8".into()),
@@ -412,7 +412,7 @@ pub async fn test_query_mine_with_content_full() {
     .call(
       &cell1.zome("trust_atom"),
       "query_mine",
-      trust_atom::QueryMineInput {
+      trust_atom_types::QueryMineInput {
         target: None,
         content_full: Some("sushi".into()),
         content_starts_with: None,
@@ -443,7 +443,7 @@ pub async fn test_get_extra() {
     )
     .await;
 
-  let mock_input = trust_atom::TrustAtomInput {
+  let mock_input = trust_atom_types::TrustAtomInput {
     target: target_hash,
     content: Some("sushi".to_string()),
     value: Some("0.9871".to_string()),

--- a/zomes/trust_atom_types/Cargo.toml
+++ b/zomes/trust_atom_types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "trust_atom_types"
+description = "Holochain implementation of TrustAtom format from TrustGraph"
+version = "0.1.1-dev"
+authors = ["harlantwood", "code@harlantwood.net"]
+edition = "2021"
+rust-version = "1.56.0" # require rust >= 1.56, required to enable 2021 edition
+
+[lib]
+name = "trust_atom_types"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = "=0.1.1"
+serde = "1"

--- a/zomes/trust_atom_types/src/lib.rs
+++ b/zomes/trust_atom_types/src/lib.rs
@@ -1,0 +1,41 @@
+#![warn(warnings)]
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![deny(clippy::nursery)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::unwrap_in_result)]
+#![allow(clippy::missing_errors_doc)] // TODO fix and remove this
+#![allow(clippy::missing_const_for_fn)]
+#![allow(clippy::or_fun_call)]
+#![allow(clippy::option_if_let_else)]
+// #![warn(clippy::cargo)]
+
+use hdk::prelude::*;
+use std::collections::BTreeMap;
+
+// INPUT TYPES
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct TrustAtomInput {
+  pub target: AnyLinkableHash,
+  pub content: Option<String>,
+  pub value: Option<String>,
+  pub extra: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct QueryInput {
+  pub source: Option<AnyLinkableHash>,
+  pub target: Option<AnyLinkableHash>,
+  pub content_full: Option<String>,
+  pub content_starts_with: Option<String>,
+  pub value_starts_with: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct QueryMineInput {
+  pub target: Option<AnyLinkableHash>,
+  pub content_full: Option<String>,
+  pub content_starts_with: Option<String>,
+  pub value_starts_with: Option<String>,
+}


### PR DESCRIPTION
Enables using them from importing projects