### PR TITLE
Move LinkTypes from types crate to integrity crate

### DIFF
--- a/zomes/trust_atom/src/lib.rs
+++ b/zomes/trust_atom/src/lib.rs
@@ -15,8 +15,8 @@ mod trust_atom;
 pub(crate) use trust_atom_integrity::entries::{Example, Extra};
 use trust_atom_integrity::headers::build_forward_header;
 pub(crate) use trust_atom_integrity::headers::build_reverse_header;
+pub(crate) use trust_atom_integrity::LinkTypes;
 use trust_atom_types::DeleteReport;
-pub(crate) use trust_atom_types::LinkTypes;
 pub(crate) use trust_atom_types::{QueryInput, QueryMineInput, TrustAtom, TrustAtomInput};
 pub(crate) mod test_helpers;
 

--- a/zomes/trust_atom/src/test_helpers.rs
+++ b/zomes/trust_atom/src/test_helpers.rs
@@ -2,7 +2,7 @@
 
 use hdk::prelude::*;
 use trust_atom_integrity::entries::{EntryTypes, Example, StringTarget};
-use trust_atom_types::LinkTypes;
+use trust_atom_integrity::LinkTypes;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StringLinkTag(pub String);

--- a/zomes/trust_atom/src/trust_atom.rs
+++ b/zomes/trust_atom/src/trust_atom.rs
@@ -7,7 +7,7 @@ use trust_atom_integrity::entries::{EntryTypes, Extra};
 use trust_atom_integrity::headers::{
   LINK_TAG_ARROW_FORWARD, LINK_TAG_ARROW_REVERSE, LINK_TAG_HEADER, UNICODE_NUL_STR,
 };
-use trust_atom_types::LinkTypes;
+use trust_atom_integrity::LinkTypes;
 use trust_atom_types::TrustAtom;
 
 #[derive(Debug, Clone)]

--- a/zomes/trust_atom_integrity/src/entries.rs
+++ b/zomes/trust_atom_integrity/src/entries.rs
@@ -1,6 +1,5 @@
 use hdi::prelude::*;
 use std::collections::BTreeMap;
-pub use trust_atom_types::LinkTypes;
 
 #[hdk_entry_helper]
 #[derive(Clone)]

--- a/zomes/trust_atom_integrity/src/lib.rs
+++ b/zomes/trust_atom_integrity/src/lib.rs
@@ -1,3 +1,10 @@
+use hdi::prelude::*;
 pub mod entries;
 pub mod headers;
 pub mod validation;
+
+#[derive(Serialize, Deserialize)]
+#[hdk_link_types]
+pub enum LinkTypes {
+  TrustAtom,
+}

--- a/zomes/trust_atom_types/src/lib.rs
+++ b/zomes/trust_atom_types/src/lib.rs
@@ -13,12 +13,6 @@
 use hdk::prelude::*;
 use std::collections::BTreeMap;
 
-#[derive(Serialize, Deserialize)]
-#[hdk_link_types]
-pub enum LinkTypes {
-  TrustAtom,
-}
-
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 pub struct TrustAtomInput {
   pub target: AnyLinkableHash,


### PR DESCRIPTION
Needed for client apps that import types crate (and define their own link types) under hdk 0.1.2.  May be able to revert this after hdk 0.2.x.